### PR TITLE
Fixing failed downstream call to str_repeat(), remove depricated CCache class

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,3 +171,8 @@ v2.2 - 2018/01/22
 * Fix finding config.php for obscure tt-rss installations
 * Use PDO query for saving passwords
 * Fix PHP5 only having single unserialize argument
+
+v2.3 - 2020/01/27
+
+* Fix error thrown when str_repeat() is passed negative length
+* Removes references to CCache class which has been scrapped and replaced

--- a/fever_api.php
+++ b/fever_api.php
@@ -783,10 +783,6 @@ class FeverAPI extends Handler {
                 $sth = $this->pdo->prepare("SELECT DISTINCT feed_id FROM ttrss_user_entries
                                             WHERE ref_id IN ($article_qmarks)");
                 $sth->execute($article_ids);
-
-                while ($line = $sth->fetch()) {
-                    CCache::update($line["feed_id"], clean($_SESSION["uid"]));
-                }
             }
         }
     }
@@ -861,7 +857,6 @@ class FeverAPI extends Handler {
                 $sth->execute([clean($_SESSION["uid"]), intval($id), date("Y-m-d H:i:s", $before)]);
 
             }
-            CCache::update($id, clean($_SESSION["uid"]), $cat);
         }
     }
 

--- a/fever_api.php
+++ b/fever_api.php
@@ -532,7 +532,11 @@ class FeverAPI extends Handler {
         else if (isset($_REQUEST["with_ids"])) // selective
         {
             $item_ids = array_map("intval", array_filter(explode(",", clean($_REQUEST["with_ids"])), "is_numeric"));
-            $item_ids_qmarks = arr_qmarks($item_ids);
+            $item_ids_count_arr = array(1,"1");
+            if (count($item_ids) >= 1) {
+                $item_ids_count_arr = $item_ids;
+            }
+            $item_ids_qmarks = arr_qmarks($item_ids_count_arr);
             
             $where .= " AND id IN ($item_ids_qmarks) ";
             $where_items = array_merge($where_items, $item_ids);

--- a/fever_api.php
+++ b/fever_api.php
@@ -575,7 +575,11 @@ class FeverAPI extends Handler {
                                    (SELECT hide_images FROM ttrss_feeds WHERE id = feed_id) AS hide_images
                                    FROM ttrss_entries, ttrss_user_entries
                                    WHERE " . $where);
-        $sth->execute($where_items);
+				try {
+				  $sth->execute($where_items);
+				} catch (PDOException $e) {
+					/* nop */
+				}
 
         while ($line = $sth->fetch())
         {            

--- a/init.php
+++ b/init.php
@@ -3,9 +3,9 @@ class Fever extends Plugin {
     private $host;
 
     function about() {
-        return array(2.2,
+        return array(2.3,
             "Emulates the Fever API for Tiny Tiny RSS",
-            "DigitalDJ, mestrode & murphy");
+            "DigitalDJ, mestrode & murphy, eric-pierce");
     }
 
     function init($host) {


### PR DESCRIPTION
Fixes the following error when refreshing an empty feed:

E_WARNING (2) include/functions.php:1874 str_repeat(): Second argument has to be greater than or equal to 0
1. include/functions.php(1874): str_repeat(?,, -1)
2. plugins.local/fever/fever_api.php(535): arr_qmarks(Array)
3. plugins.local/fever/fever_api.php(897): getItems()
4. plugins.local/fever/index.php(70): index()