### PR TITLE
Suppress "Undefined array key" warnings now that they're no longer notices

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,3 +176,8 @@ v2.3 - 2020/01/27
 
 * Fix error thrown when str_repeat() is passed negative length
 * Removes references to CCache class which has been scrapped and replaced
+
+v2.4 - 2021/02/16
+
+* Includes fixes by froks to fix for the latest changes in tiny-tiny-rss
+* Includes updates to account for the "Undefined array key' error upgrade from notice to warning in PHP8

--- a/fever_api.php
+++ b/fever_api.php
@@ -294,8 +294,10 @@ class FeverAPI extends Handler {
                 {
                     $groupsToGroups[-1] = array();
                 }
-
-                array_push($groupsToGroups[-1], $line["order_id"] . "-" . $line["id"]);
+		if (isset($line["order_id"]) && isset($line["id"]))
+		{
+                	array_push($groupsToGroups[-1], $line["order_id"] . "-" . $line["id"]);
+		}
             }
             else
             {
@@ -303,8 +305,10 @@ class FeverAPI extends Handler {
                 {
                     $groupsToGroups[$line["parent_cat"]] = array();
                 }
-
-                array_push($groupsToGroups[$line["parent_cat"]], $line["order_id"] . "-" . $line["id"]);
+		if (isset($line["order_id"]) && isset($line["id"]))
+		{
+                	array_push($groupsToGroups[$line["parent_cat"]], $line["order_id"] . "-" . $line["id"]);
+		}
             }
 
             $groupsToTitle[$line["id"]] = $line["title"];

--- a/index.php
+++ b/index.php
@@ -53,7 +53,7 @@
         ob_start();
     }
         
-    if ($_REQUEST["sid"]) {
+    if (isset($_REQUEST["sid"])) {
         session_id($_REQUEST["sid"]);
         @session_start();
     } else if (defined('_API_DEBUG_HTTP_ENABLED')) {


### PR DESCRIPTION
Just added a few "isset" checks to avoid the new warnings added in PHP8